### PR TITLE
Resign IR value naming and clean up.

### DIFF
--- a/FileCheck/anonymous.dl
+++ b/FileCheck/anonymous.dl
@@ -1,0 +1,70 @@
+// RUN: dlopt %s -p DCE --print-ir | FileCheck %s
+
+// CHECK: DCE: changed
+
+module "mnist"
+stage raw
+
+struct $MNIST {
+    #w: <784 x 10 x f32>
+    #b: <1 x 10 x f32>
+}
+
+type $MyMnist = $MNIST
+
+var @0: $MNIST
+var @1: <10000 x 20000 x f16>
+
+func @2: (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>) -> <1 x 10 x f32> {
+'0(%x: <1 x 784 x f32>, %w: <784 x 10 x f32>, %b: <1 x 10 x f32>):
+    %0.0 = dot %x: <1 x 784 x f32>, %w: <784 x 10 x f32>
+    %0.1 = add %0.0: <1 x 10 x f32>, %b: <1 x 10 x f32>
+    return %0.1: <1 x 10 x f32>
+}
+
+!inline
+func @3: () -> <1 x 10 x f32> {
+'entry():
+    %x = literal 1: <1 x 784 x f32>
+    %w = literal 2: <784 x 10 x f32>
+    %b = literal 3: <1 x 10 x f32>
+    %0.3 = apply @2(%x: <1 x 784 x f32>, %w: <784 x 10 x f32>, %b: <1 x 10 x f32>): (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>) -> <1 x 10 x f32>
+    %dead0 = apply @2(%x: <1 x 784 x f32>, %w: <784 x 10 x f32>, %b: <1 x 10 x f32>): (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>) -> <1 x 10 x f32>
+    %dead1 = add 1: f32, %dead0: <1 x 10 x f32>
+    return %0.3: <1 x 10 x f32>
+}
+
+// CHECK: func @3: () -> <1 x 10 x f32>
+// CHECK: %x = literal 1: <1 x 784 x f32>
+// CHECK-NEXT: %w = literal 2: <784 x 10 x f32>
+// CHECK-NEXT: %b = literal 3: <1 x 10 x f32>
+// CHECK-NEXT: %0.3 = apply @2(%x: <1 x 784 x f32>, %w: <784 x 10 x f32>, %b: <1 x 10 x f32>): (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>) -> <1 x 10 x f32>
+// CHECK-NEXT: return %0.3: <1 x 10 x f32>
+
+func @4: () -> <2 x 2 x f32> {
+'0():
+    %a = random scalar from 0.0: f32 upto 1.0: f32
+    %b = random 4 from 0.0: f32 upto 1.0: f32
+    %c = literal <<true: bool, false: bool>: <2 x bool>, <true: bool, false: bool>: <2 x bool>>: <2 x 2 x bool>
+    %d = shapeCast %c: <2 x 2 x bool> to 4
+    %e = select %a: f32, %b: <4 x f32> by %d: <4 x bool>
+    %f = shapeCast %e: <4 x f32> to 2 x 2
+    %g = literal <<1: f32>: <1 x f32>>: <1 x 1 x f32>
+    %h = shapeCast %g: <1 x 1 x f32> to scalar
+    %i = greaterThan %f: <2 x 2 x f32>, %h: f32
+    %all = reduce %i: <2 x 2 x bool> by and init true: bool along 0, 1
+    conditional %all: bool then '1(%h: f32) else '2(%h: f32)
+'1(%k: f32):
+    %k1 = shapeCast %k: f32 to 1
+    %kv1 = concatenate %k1: <1 x f32>, %k1: <1 x f32>, %k1: <1 x f32>, %k1: <1 x f32> along 0
+    %kr1 = shapeCast %kv1: <4 x f32> to 2 x 2
+    return %kr1: <2 x 2 x f32>
+'2(%n: f32):
+    %k2 = shapeCast %n: f32 to 1
+    %kv2 = concatenate %k2: <1 x f32>, %k2: <1 x f32>, %k2: <1 x f32>, %k2: <1 x f32> along 0
+    %kr2 = shapeCast %kv2: <4 x f32> to 2 x 2
+    return %kr2: <2 x 2 x f32>
+}
+
+[adjoint @2 wrt 0 seedable]
+func @5: (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>, <1 x 10 x f32>) -> (<1 x 784 x f32>)

--- a/FileCheck/cfg_canonicalization.dl
+++ b/FileCheck/cfg_canonicalization.dl
@@ -32,8 +32,8 @@ func @foo: (i32) -> i32 {
 // CHECK-NEXT:     branch 'then_join(0: i32)
 // CHECK-NEXT: 'nested_else():
 // CHECK-NEXT:     branch 'then_join(1: i32)
-// CHECK-NEXT: 'then_join(%exit_value_0: i32):
-// CHECK-NEXT:     branch 'exit(%exit_value_0: i32)
+// CHECK-NEXT: 'then_join(%5^0: i32):
+// CHECK-NEXT:     branch 'exit(%5^0: i32)
 // CHECK-NEXT: 'exit(%exit_value: i32):
 // CHECK-NEXT:     return %exit_value: i32
 
@@ -66,8 +66,8 @@ func @double_loop: (i32, i32) -> i32 {
 // CHECK-NEXT: 'outer(%i1: i32, %j1: i32):
 // CHECK-NEXT:     %1.0 = lessThan %i1: i32, %a: i32
 // CHECK-NEXT:     conditional %1.0: bool then 'inner_preheader(%i1: i32, %j1: i32) else 'cont()
-// CHECK-NEXT: 'inner_preheader(%i2_0: i32, %j2_0: i32):
-// CHECK-NEXT:     branch 'inner(%i2_0: i32, %j2_0: i32)
+// CHECK-NEXT: 'inner_preheader(%2^0: i32, %2^1: i32):
+// CHECK-NEXT:     branch 'inner(%2^0: i32, %2^1: i32)
 // CHECK-NEXT: 'inner(%i2: i32, %j2: i32):
 // CHECK-NEXT:     %3.0 = lessThan %j2: i32, %b: i32
 // CHECK-NEXT:     conditional %3.0: bool then 'inner_body() else 'outer_body()

--- a/FileCheck/enum.dl
+++ b/FileCheck/enum.dl
@@ -11,18 +11,6 @@ enum $TestEnum1 {
     ?baz($TestEnum1, <1 x 3 x 4 x f64>, $TestEnum1)
 }
 
-var @enum1: $TestEnum1
-
-func @initialize_enum1: () -> () {
-'entry():
-    %0.0 = literal undefined: <1 x 3 x 4 x f64>
-    %0.1 = literal ?foo(123: i32, 3.14: f32): $TestEnum1
-    %0.2 = literal ?bar(): $TestEnum1
-    %0.3 = literal ?baz(%0.1: $TestEnum1, %0.0: <1 x 3 x 4 x f64>, %0.2: $TestEnum1): $TestEnum1
-    store %0.3: $TestEnum1 to @enum1: *$TestEnum1
-    return
-}
-
 enum $Tree {
     ?word(<1 x f32>)
     ?combine($Tree, <2 x f32>, $Tree)
@@ -33,6 +21,18 @@ struct $Classifier {
     #w2: <1 x 2 x f32>
     #b1: <1 x f32>
     #b2: <1 x f32>
+}
+
+var @enum1: $TestEnum1
+
+func @initialize_enum1: () -> () {
+'entry():
+    %0.0 = literal undefined: <1 x 3 x 4 x f64>
+    %0.1 = literal ?foo(123: i32, 3.14: f32): $TestEnum1
+    %0.2 = literal ?bar(): $TestEnum1
+    %0.3 = literal ?baz(%0.1: $TestEnum1, %0.0: <1 x 3 x 4 x f64>, %0.2: $TestEnum1): $TestEnum1
+    store %0.3: $TestEnum1 to @enum1: *$TestEnum1
+    return
 }
 
 func @prediction: ($Classifier, $Tree) -> <1 x 2 x f32> {

--- a/FileCheck/test0.dl
+++ b/FileCheck/test0.dl
@@ -12,6 +12,9 @@ struct $MNIST {
 
 type $MyMnist = $MNIST
 
+var @x: $MNIST
+var @1: <10000 x 20000 x f16>
+
 func @inference: (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>) -> <1 x 10 x f32> {
 'entry(%x: <1 x 784 x f32>, %w: <784 x 10 x f32>, %b: <1 x 10 x f32>):
     %0.0 = dot %x: <1 x 784 x f32>, %w: <784 x 10 x f32>
@@ -62,9 +65,6 @@ func @foo2: () -> <2 x 2 x f32> {
     %kr2 = shapeCast %kv2: <4 x f32> to 2 x 2
     return %kr2: <2 x 2 x f32>
 }
-
-var @x: $MNIST
-var @test_tensor: <10000 x 20000 x f16>
 
 [adjoint @inference wrt 0 seedable]
 func @baz: (<1 x 784 x f32>, <784 x 10 x f32>, <1 x 10 x f32>, <1 x 10 x f32>) -> (<1 x 784 x f32>)

--- a/Sources/DLParse/Diagnostics.swift
+++ b/Sources/DLParse/Diagnostics.swift
@@ -215,8 +215,9 @@ extension LexicalError : CustomStringConvertible {
             desc += "expecting identifier name"
         case .invalidAnonymousLocalIdentifier(_):
             desc += """
-                invalid anonymous local identifier. It should look like \
-                %<bb_index>.<inst_index|arg_index>, e.g. %0.1 or %0^1
+                invalid anonymous local identifier. It should look either like \
+                %<bb_index>.<inst_index> or %<bb_index>^<arg_index>, e.g. \
+                %0.1 or %0^1
                 """
         case .invalidBasicBlockIndex(_):
             desc += """

--- a/Sources/DLParse/Diagnostics.swift
+++ b/Sources/DLParse/Diagnostics.swift
@@ -28,7 +28,7 @@ public enum LexicalError : Error {
     case expectingIdentifierName(SourceLocation)
     case invalidAnonymousLocalIdentifier(SourceLocation)
     case invalidBasicBlockIndex(SourceLocation)
-    case invalidInstructionIndex(SourceLocation)
+    case invalidAnonymousIdentifierIndex(SourceLocation)
     case unknownAttribute(SourceRange)
 }
 
@@ -42,7 +42,12 @@ public enum ParseError : Error {
     case undefinedNominalType(Token)
     case redefinedIdentifier(Token)
     case anonymousIdentifierNotInLocal(Token)
-    case invalidAnonymousIdentifierIndex(Token)
+    case invalidInstructionIndex(Token)
+    case invalidArgumentIndex(Token)
+    case invalidBasicBlockIndex(Token)
+    case invalidVariableIndex(Token)
+    case invalidFunctionIndex(Token)
+    case variableAfterFunction(Token)
     case notFunctionType(SourceRange)
     case notInBasicBlock(SourceRange)
     case invalidAttributeArguments(SourceLocation)
@@ -58,7 +63,7 @@ public extension LexicalError {
              .invalidEscapeCharacter(_, let loc),
              .unexpectedToken(let loc),
              .invalidBasicBlockIndex(let loc),
-             .invalidInstructionIndex(let loc),
+             .invalidAnonymousIdentifierIndex(let loc),
              .invalidAnonymousLocalIdentifier(let loc):
             return loc
         case .illegalIdentifier(let range),
@@ -83,7 +88,12 @@ public extension ParseError {
              let .undefinedNominalType(tok),
              let .redefinedIdentifier(tok),
              let .anonymousIdentifierNotInLocal(tok),
-             let .invalidAnonymousIdentifierIndex(tok),
+             let .invalidInstructionIndex(tok),
+             let .invalidArgumentIndex(tok),
+             let .invalidBasicBlockIndex(tok),
+             let .invalidVariableIndex(tok),
+             let .invalidFunctionIndex(tok),
+             let .variableAfterFunction(tok),
              let .declarationCannotHaveBody(_, body: tok),
              let .cannotNameVoidValue(tok),
              let .invalidOperands(tok, _):
@@ -132,8 +142,18 @@ extension ParseError : CustomStringConvertible {
                 anonymous identifier \(tok) is not in a local (basic block) \
                 context
                 """
-        case let .invalidAnonymousIdentifierIndex(tok):
-            desc += "anonymous identifier \(tok) has invalid index"
+        case let .invalidInstructionIndex(tok):
+            desc += "anonymous instruction \(tok) has invalid index"
+        case let .invalidArgumentIndex(tok):
+            desc += "anonymous argument \(tok) has invalid index"
+        case let .invalidBasicBlockIndex(tok):
+            desc += "anonymous basic block \(tok) has invalid index"
+        case let .invalidVariableIndex(tok):
+            desc += "anonymous variable \(tok) has invalid index"
+        case let .invalidFunctionIndex(tok):
+            desc += "anonymous function \(tok) has invalid index"
+        case let .variableAfterFunction(tok):
+            desc += "variable \(tok) not declared before functions"
         case let .notFunctionType(range):
             desc += "type signature at \(range) is not a function type"
         case let .notInBasicBlock(range):
@@ -182,16 +202,14 @@ extension LexicalError : CustomStringConvertible {
         case .invalidAnonymousLocalIdentifier(_):
             desc += """
                 invalid anonymous local identifier. It should look like \
-                %<bb_index>.<inst_index>, e.g. %0.1
+                %<bb_index>.<inst_index|arg_index>, e.g. %0.1 or %0^1
                 """
         case .invalidBasicBlockIndex(_):
             desc += """
                 invalid index for basic block in anonymous local identifier
                 """
-        case .invalidInstructionIndex(_):
-            desc += """
-                invalid index for instruction in anonymous local identifier
-                """
+        case .invalidAnonymousIdentifierIndex(_):
+            desc += "invalid index in anonymous identifier"
         case let .unknownAttribute(range):
             desc += "unknown attribute at \(range)"
         }
@@ -297,7 +315,13 @@ extension TokenKind : CustomStringConvertible {
             return kindDesc + id
         case let .stringLiteral(str): return "\"\(str)\""
         case .newLine: return "a new line"
-        case let .anonymousIdentifier(b, i):
+        case let .anonymousGlobal(i):
+            return "@\(i)"
+        case let .anonymousArgument(b, i):
+            return "%\(b)^\(i)"
+        case let .anonymousBasicBlock(i):
+            return "'\(i)"
+        case let .anonymousInstruction(b, i):
             return "%\(b).\(i)"
         case let .attribute(attr):
             return String(describing: attr)

--- a/Sources/DLParse/Diagnostics.swift
+++ b/Sources/DLParse/Diagnostics.swift
@@ -48,6 +48,7 @@ public enum ParseError : Error {
     case invalidVariableIndex(Token)
     case invalidFunctionIndex(Token)
     case variableAfterFunction(Token)
+    case typeDeclarationNotBeforeValues(Token)
     case notFunctionType(SourceRange)
     case notInBasicBlock(SourceRange)
     case invalidAttributeArguments(SourceLocation)
@@ -94,6 +95,7 @@ public extension ParseError {
              let .invalidVariableIndex(tok),
              let .invalidFunctionIndex(tok),
              let .variableAfterFunction(tok),
+             let .typeDeclarationNotBeforeValues(tok),
              let .declarationCannotHaveBody(_, body: tok),
              let .cannotNameVoidValue(tok),
              let .invalidOperands(tok, _):
@@ -154,6 +156,8 @@ extension ParseError : CustomStringConvertible {
             desc += "anonymous function \(tok) has invalid index"
         case let .variableAfterFunction(tok):
             desc += "variable \(tok) not declared before functions"
+        case let .typeDeclarationNotBeforeValues(tok):
+            desc += "type \(tok) not declared before value"
         case let .notFunctionType(range):
             desc += "type signature at \(range) is not a function type"
         case let .notInBasicBlock(range):

--- a/Sources/DLParse/Parse.swift
+++ b/Sources/DLParse/Parse.swift
@@ -1594,12 +1594,21 @@ public extension Parser {
         while let tok = currentToken {
             switch tok.kind {
             case .keyword(.type):
+                guard module.isEmpty, module.variables.isEmpty else {
+                    throw ParseError.typeDeclarationNotBeforeValues(tok)
+                }
                 _ = try parseTypeAlias(in: module, isDefinition: false)
 
             case .keyword(.struct):
+                guard module.isEmpty, module.variables.isEmpty else {
+                    throw ParseError.typeDeclarationNotBeforeValues(tok)
+                }
                 _ = try parseStruct(in: module, isDefinition: false)
 
             case .keyword(.enum):
+                guard module.isEmpty, module.variables.isEmpty else {
+                    throw ParseError.typeDeclarationNotBeforeValues(tok)
+                }
                 _ = try parseEnum(in: module, isDefinition: false)
 
             case .keyword(.func), .attribute(_), .punctuation(.leftSquareBracket):

--- a/Sources/DLParse/Parse.swift
+++ b/Sources/DLParse/Parse.swift
@@ -54,7 +54,6 @@ public class Parser {
 // MARK: - Common routines and combinators
 
 private extension Parser {
-
     var currentToken: Token? {
         guard let first = restTokens.first else { return nil }
         return first
@@ -173,7 +172,9 @@ private extension Parser {
         }
     }
 
-    func parseIdentifier(ofKind kind: IdentifierKind, isDefinition: Bool = false) throws -> (String, Token) {
+    func parseIdentifier(
+        ofKind kind: IdentifierKind, isDefinition: Bool = false
+    ) throws -> (String, Token) {
         let tok = try consumeOrDiagnose("an identifier")
         let name: String
         switch tok.kind {
@@ -248,13 +249,15 @@ private extension Parser {
 
     /// Parse one or more with optional backtracking
     /// - Note: In the first closure, return `nil` to backtrack
-    func parseMany<T>(_ parseElement: () throws -> T?, unless: ((Token) -> Bool)? = nil,
-                      separatedBy parseSeparator: () throws -> ()) rethrows -> [T] {
+    func parseMany<T>(
+        _ parseElement: () throws -> T?, unless: ((Token) -> Bool)? = nil,
+        separatedBy parseSeparator: () throws -> ()
+    ) rethrows -> [T] {
         guard let tok = currentToken else { return [] }
         if let unless = unless, unless(tok) { return [] }
         guard let first = try withBacktracking(parseElement) else { return [] }
         var elements: [T] = []
-        while let _ = withBacktracking({try? parseSeparator()}),
+        while let _ = withBacktracking({ try? parseSeparator() }),
             let result = try withBacktracking(parseElement) {
             elements.append(result)
         }
@@ -266,7 +269,9 @@ private extension Parser {
 
 extension Parser {
     /// Parse uses separated by ','
-    func parseUseList(in basicBlock: BasicBlock?, unless: ((Token) -> Bool)? = nil) throws -> [Use] {
+    func parseUseList(
+        in basicBlock: BasicBlock?, unless: ((Token) -> Bool)? = nil
+    ) throws -> [Use] {
         return try parseMany({ try parseUse(in: basicBlock).0 },
                              unless: unless,
                              separatedBy: { try self.consumeWrappablePunctuation(.comma) })
@@ -399,7 +404,8 @@ extension Parser {
                 default:
                     return nil
                 }
-        })
+            }
+        )
     }
 
     func parseReductionCombinator(in basicBlock: BasicBlock?) throws -> ReductionCombinator {
@@ -418,7 +424,8 @@ extension Parser {
                 default:
                     return nil
                 }
-        })
+            }
+        )
     }
 
     func parseElementKey(in basicBlock: BasicBlock?) throws -> (ElementKey, SourceRange) {
@@ -536,8 +543,28 @@ extension Parser {
             guard type == use.type else {
                 throw ParseError.typeMismatch(expected: use.type, range)
             }
-        /// Anonymous local identifier in a basic block
-        case let .anonymousIdentifier(bbIndex, instIndex):
+        /// Anonymous global identifier
+        case let .anonymousGlobal(index):
+            guard let bb = basicBlock else {
+                throw ParseError.anonymousIdentifierNotInLocal(tok)
+            }
+            consumeToken()
+            let module = bb.parent.parent
+            if index < module.variables.count {
+                let variable = module.variables[index]
+                use = %variable
+            } else {
+                let funcIndex = index - module.variables.count
+                let function = module[funcIndex]
+                use = %function
+            }
+            let (type, typeSigRange) = try parseTypeSignature()
+            range = tok.startLocation..<typeSigRange.upperBound
+            guard type == use.type else {
+                throw ParseError.typeMismatch(expected: use.type, range)
+            }
+        /// Anonymous instruction in a basic block
+        case let .anonymousInstruction(bbIndex, instIndex):
             guard let bb = basicBlock else {
                 throw ParseError.anonymousIdentifierNotInLocal(tok)
             }
@@ -547,11 +574,11 @@ extension Parser {
             /// - BB referred to must precede the current BB
             /// - Instruction referred to must precede the current instruction
             guard bbIndex <= function.endIndex else {
-                throw ParseError.invalidAnonymousIdentifierIndex(tok)
+                throw ParseError.invalidInstructionIndex(tok)
             }
             let refBB = bbIndex == function.endIndex ? bb : function[bbIndex]
             guard refBB.indices.contains(instIndex) else {
-                throw ParseError.invalidAnonymousIdentifierIndex(tok)
+                throw ParseError.invalidInstructionIndex(tok)
             }
             let inst = refBB[instIndex]
             /// This value cannot be named, or have void type
@@ -560,6 +587,34 @@ extension Parser {
             }
             /// Now we can use this value
             use = %inst
+            let (type, typeSigRange) = try parseTypeSignature()
+            range = tok.startLocation..<typeSigRange.upperBound
+            guard type == use.type else {
+                throw ParseError.typeMismatch(expected: use.type, range)
+            }
+        /// Anonymous argument in a basic block
+        case let .anonymousArgument(bbIndex, argIndex):
+            guard let bb = basicBlock else {
+                throw ParseError.anonymousIdentifierNotInLocal(tok)
+            }
+            consumeToken()
+            let function = bb.parent
+            /// Criteria for identifier index:
+            /// - BB referred to must precede the current BB
+            guard bbIndex <= function.endIndex else {
+                throw ParseError.invalidArgumentIndex(tok)
+            }
+            let refBB = bbIndex == function.endIndex ? bb : function[bbIndex]
+            guard refBB.arguments.indices.contains(argIndex) else {
+                throw ParseError.invalidArgumentIndex(tok)
+            }
+            let arg = refBB.arguments[argIndex]
+            /// This value cannot be named, or have void type
+            guard arg.name == nil, arg.type != .void else {
+                throw ParseError.undefinedIdentifier(tok)
+            }
+            /// Now we can use this value
+            use = %arg
             let (type, typeSigRange) = try parseTypeSignature()
             range = tok.startLocation..<typeSigRange.upperBound
             guard type == use.type else {
@@ -589,7 +644,6 @@ extension Parser {
             consumeToken()
             return opcode
         }
-        /// - todo: parse instruction kind
         switch opcode {
         /// 'literal' <literal> ':' <type>
         case .literal:
@@ -599,7 +653,16 @@ extension Parser {
 
         /// 'branch' <bb> '(' (<val> (',' <val>)*)? ')'
         case .branch:
-            let (bbName, bbTok) = try parseIdentifier(ofKind: .basicBlock)
+            let bbTok = try consumeOrDiagnose("a basic block identifier")
+            let bbName: String
+            switch bbTok.kind {
+            case let .identifier(.basicBlock, name):
+                bbName = name
+            case let .anonymousBasicBlock(index):
+                bbName = String(index)
+            default:
+                throw ParseError.unexpectedToken(expected: "a basic block identifier", bbTok)
+            }
             guard let bb = environment.basicBlocks[bbName] else {
                 throw ParseError.undefinedIdentifier(bbTok)
             }
@@ -615,7 +678,16 @@ extension Parser {
             let (cond, _) = try parseUse(in: basicBlock)
             /// Then
             try consume(.keyword(.then))
-            let (thenBBName, thenBBTok) = try parseIdentifier(ofKind: .basicBlock)
+            let thenBBTok = try consumeOrDiagnose("a basic block identifier")
+            let thenBBName: String
+            switch thenBBTok.kind {
+            case let .identifier(.basicBlock, name):
+                thenBBName = name
+            case let .anonymousBasicBlock(index):
+                thenBBName = String(index)
+            default:
+                throw ParseError.unexpectedToken(expected: "a basic block identifier", thenBBTok)
+            }
             guard let thenBB = environment.basicBlocks[thenBBName] else {
                 throw ParseError.undefinedIdentifier(thenBBTok)
             }
@@ -625,7 +697,16 @@ extension Parser {
             try consume(.punctuation(.rightParenthesis))
             /// Else
             try consume(.keyword(.else))
-            let (elseBBName, elseBBTok) = try parseIdentifier(ofKind: .basicBlock)
+            let elseBBTok = try consumeOrDiagnose("a basic block identifier")
+            let elseBBName: String
+            switch elseBBTok.kind {
+            case let .identifier(.basicBlock, name):
+                elseBBName = name
+            case let .anonymousBasicBlock(index):
+                elseBBName = String(index)
+            default:
+                throw ParseError.unexpectedToken(expected: "a basic block identifier", elseBBTok)
+            }
             guard let elseBB = environment.basicBlocks[elseBBName] else {
                 throw ParseError.undefinedIdentifier(elseBBTok)
             }
@@ -850,7 +931,16 @@ extension Parser {
                 }
                 try consume(.keyword(.case))
                 let caseName = try parseIdentifier(ofKind: .enumCase).0
-                let (bbName, bbTok) = try parseIdentifier(ofKind: .basicBlock)
+                let bbTok = try consumeOrDiagnose("a basic block identifier")
+                let bbName: String
+                switch bbTok.kind {
+                case let .identifier(.basicBlock, name):
+                    bbName = name
+                case let .anonymousBasicBlock(index):
+                    bbName = String(index)
+                default:
+                    throw ParseError.unexpectedToken(expected: "a basic block identifier", bbTok)
+                }
                 guard let bb = environment.basicBlocks[bbName] else {
                     throw ParseError.undefinedIdentifier(bbTok)
                 }
@@ -861,7 +951,18 @@ extension Parser {
         /// 'apply' <val> '(' <val>+ ')'
         case .apply:
             return try withPeekedToken("a function identifier") { tok in
-                guard case let .identifier(kind, name) = tok.kind else { return nil }
+                let kind: IdentifierKind
+                let name: String
+                switch tok.kind {
+                case let .identifier(funcKind, funcName):
+                    kind = funcKind
+                    name = funcName
+                case let .anonymousGlobal(index):
+                    kind = .global
+                    name = String(index)
+                default:
+                    return nil
+                }
                 consumeToken()
                 let fn: Value
                 switch kind {
@@ -1052,14 +1153,14 @@ extension Parser {
             let inst = Instruction(name: name, kind: kind, parent: basicBlock)
             environment.locals[name] = inst
             return inst
-        case let .anonymousIdentifier(bbIndex, instIndex):
+        case let .anonymousInstruction(bbIndex, instIndex):
             /// Check BB index and instruction index
             /// - BB index must equal the current BB index
             /// - Instruction index must equal the next instruction index,
             ///   i.e. the current instruction count
             guard bbIndex == basicBlock.parent.count, // BB hasn't been added to function
                 instIndex == basicBlock.endIndex // Inst hasn't been added to BB
-                else { throw ParseError.invalidAnonymousIdentifierIndex(tok) }
+                else { throw ParseError.invalidInstructionIndex(tok) }
             consumeToken()
             try consumeWrappablePunctuation(.equal)
             let kind = try parseKind(isNamed: true)
@@ -1085,9 +1186,22 @@ extension Parser {
 
     func parseBasicBlock(in function: Function) throws -> BasicBlock? {
         /// Parse basic block header.
-        guard let nameTok = currentToken,
-            case .identifier(.basicBlock, let name) = nameTok.kind else {
+        guard let nameTok = currentToken else { return nil }
+        let name: String
+        switch nameTok.kind {
+        case let .identifier(.basicBlock, bbName):
+            name = bbName
+        case let .anonymousBasicBlock(index):
+            /// Check basic block index
+            /// - bb index must equal the next bb index,
+            ///   i.e. the current bb count.
+            guard index == function.count
+                else { throw ParseError.invalidBasicBlockIndex(nameTok) }
+            name = String(index)
+        case .punctuation(.rightCurlyBracket):
             return nil
+        default:
+            throw ParseError.unexpectedToken(expected: "a basic block identifier", nameTok)
         }
         consumeToken()
         try consumeWrappablePunctuation(.leftParenthesis)
@@ -1097,10 +1211,13 @@ extension Parser {
         try consumeOneOrMore(.newLine)
         /// Retrieve previously added BB during scanning.
         guard let bb = environment.basicBlocks[name] else {
-            preconditionFailure("Should've been added during the symbol scanning stage")
+            preconditionFailure("""
+                Basic block should have been added during the symbol scanning \
+                stage
+                """)
         }
-        /// Check if this prototype is already processed. If so, it's a redefinition
-        /// of this BB.
+        /// Check if this prototype is already processed. If so, it's a
+        /// redefinition of this BB.
         guard !environment.processedBasicBlocks.contains(bb) else {
             throw ParseError.redefinedIdentifier(nameTok)
         }
@@ -1128,7 +1245,16 @@ extension Parser {
             switch tok.kind {
             case .keyword(.adjoint):
                 consumeToken()
-                let (fnName, tok) = try parseIdentifier(ofKind: .global)
+                let fnName: String
+                let tok = try consumeOrDiagnose("a function identifier")
+                switch tok.kind {
+                case let .identifier(.global, name):
+                    fnName = name
+                case let .anonymousGlobal(index):
+                    fnName = String(index)
+                default:
+                    return nil
+                }
                 guard let fn = environment.globals[fnName] as? Function else {
                     throw ParseError.undefinedIdentifier(tok)
                 }
@@ -1198,7 +1324,21 @@ extension Parser {
         }
         /// Parse main function declaration/definition.
         let funcTok = try consume(.keyword(.func))
-        let (name, nameTok) = try parseIdentifier(ofKind: .global)
+        let nameTok = try consumeOrDiagnose("a function identifier")
+        let name: String
+        switch nameTok.kind {
+        case let .identifier(.global, funcName):
+            name = funcName
+        case let .anonymousGlobal(index):
+            /// Check global index
+            /// - Function index must equal the next function index,
+            ///   i.e. the sum of current variable and function counts
+            guard index == module.variables.count + module.count
+                else { throw ParseError.invalidFunctionIndex(nameTok) }
+            name = String(index)
+        default:
+            throw ParseError.unexpectedToken(expected: "a function identifier", nameTok)
+        }
         let (type, typeSigRange) = try parseTypeSignature()
         /// Verify that the type signature is a function type.
         guard case let .function(args, ret) = type.canonical else {
@@ -1206,7 +1346,9 @@ extension Parser {
         }
         /// Retrieve previous added function during scanning.
         guard let function = environment.globals[name] as? Function else {
-            preconditionFailure("Should've been added during the symbol scanning stage")
+            preconditionFailure("""
+                Function should have been added during the symbol scanning stage
+                """)
         }
         /// Check if this prototype is already processed. If so, it's a redefinition
         /// of this function.
@@ -1227,13 +1369,22 @@ extension Parser {
                 let (tok0, tok1) = (restTokens[start], restTokens[start+1])
                 /// End of function, break
                 if tok0.kind == .punctuation(.rightCurlyBracket) { break }
-                if case (.newLine, .identifier(.basicBlock, let name)) = (tok0.kind, tok1.kind) {
-                    let proto = BasicBlock(name: name, arguments: [], parent: function)
-                    environment.basicBlocks[name] = proto
-                    restTokens.removeFirst(2)
+                let name: String
+                var isAnonymous = false
+                switch (tok0.kind, tok1.kind) {
+                case let (.newLine, .identifier(.basicBlock, bbName)):
+                    name = bbName
+                case let (.newLine, .anonymousBasicBlock(index)):
+                    name = String(index)
+                    isAnonymous = true
+                default:
+                    consumeToken()
                     continue
                 }
-                consumeToken()
+                restTokens.removeFirst(2)
+                let proto = BasicBlock(name: isAnonymous ? nil : name,
+                                       arguments: [], parent: function)
+                environment.basicBlocks[name] = proto
             }
         }
         /// Parse definition in `{...}` when it's not a declaration.
@@ -1262,9 +1413,30 @@ extension Parser {
 
     func parseVariable(in module: Module) throws -> Variable {
         try consume(.keyword(.var))
-        let (name, _) = try parseIdentifier(ofKind: .global, isDefinition: true)
+        let tok = try consumeOrDiagnose("a variable identifier")
+        /// Variable must be declared before all functions.
+        guard module.isEmpty else {
+            throw ParseError.variableAfterFunction(tok)
+        }
+        let name: String
+        var isAnonymous = false
+        switch tok.kind {
+        case let .identifier(.global, varName):
+            name = varName
+        case let .anonymousGlobal(index):
+            /// Check global index
+            /// - Variable index must equal the next variable index,
+            ///   i.e. the current variable count
+            guard index == module.variables.count // Variable hasn't been added to module
+                else { throw ParseError.invalidVariableIndex(tok) }
+            name = String(index)
+            isAnonymous = true
+        default:
+            throw ParseError.unexpectedToken(expected: "a variable identifier", tok)
+        }
         let (type, _) = try parseTypeSignature()
-        let variable = Variable(name: name, valueType: type, parent: module)
+        let variable = Variable(name: isAnonymous ? nil : name,
+                                valueType: type, parent: module)
         environment.globals[name] = variable
         return variable
     }
@@ -1392,19 +1564,28 @@ public extension Parser {
             while restTokens.count >= 3 {
                 let start = restTokens.startIndex
                 let (tok0, tok1, tok2) = (restTokens[start], restTokens[start+1], restTokens[start+2])
-                if case (.newLine, .keyword(.func), .identifier(.global, let name)) = (tok0.kind, tok1.kind, tok2.kind) {
-                    restTokens.removeFirst(3)
-                    let (type, typeSigRange) = try parseTypeSignature()
-                    /// Verify that the type signature is a function type.
-                    guard case let .function(argTypes, retType) = type.canonical else {
-                        throw ParseError.notFunctionType(typeSigRange)
-                    }
-                    let proto = Function(name: name, argumentTypes: argTypes,
-                                         returnType: retType, parent: module)
-                    environment.globals[name] = proto
+                let name: String
+                var isAnonymous = false
+                switch (tok0.kind, tok1.kind, tok2.kind) {
+                case let (.newLine, .keyword(.func), .identifier(.global, funcName)):
+                    name = funcName
+                case let (.newLine, .keyword(.func), .anonymousGlobal(index)):
+                    name = String(index)
+                    isAnonymous = true
+                default:
+                    consumeToken()
                     continue
                 }
-                consumeToken()
+                restTokens.removeFirst(3)
+                let (type, typeSigRange) = try parseTypeSignature()
+                /// Verify that the type signature is a function type.
+                guard case let .function(argTypes, retType) = type.canonical else {
+                    throw ParseError.notFunctionType(typeSigRange)
+                }
+                let proto = Function(name: isAnonymous ? nil : name,
+                                     argumentTypes: argTypes,
+                                     returnType: retType, parent: module)
+                environment.globals[name] = proto
             }
         }
 
@@ -1431,7 +1612,7 @@ public extension Parser {
 
             default:
                 throw ParseError.unexpectedToken(
-                    expected: "a type alias, a struct, an enum, or a function", tok
+                    expected: "a type alias, a struct, an enum, a global variable, or a function", tok
                 )
             }
             if isEOF { break }

--- a/Sources/DLVM/Analysis/DFG.swift
+++ b/Sources/DLVM/Analysis/DFG.swift
@@ -112,7 +112,7 @@ open class DataFlowGraphAnalysis: AnalysisPass {
         var userGraph = DataFlowGraph()
         for inst in body.instructions {
             for use in inst.operands {
-                if let def = use.value as? Definition {
+                if case let .definition(def) = use {
                     userGraph.insert(inst, for: def)
                 }
             }

--- a/Sources/DLVM/Analysis/LoopAnalysis.swift
+++ b/Sources/DLVM/Analysis/LoopAnalysis.swift
@@ -206,12 +206,14 @@ public extension LoopInfo {
 
 extension Loop {
     func insertBlock(_ bb: BasicBlock, before other: BasicBlock) {
-        precondition(contains(other), "Loop does not contain basic block \(other.name)")
+        precondition(contains(other),
+                     "Loop does not contain basic block \(other.printedName)")
         blocks.insert(bb, before: other)
     }
 
     func insertBlock(_ bb: BasicBlock, after other: BasicBlock) {
-        precondition(contains(other), "Loop does not contain basic block \(other.name)")
+        precondition(contains(other),
+                     "Loop does not contain basic block \(other.printedName)")
         blocks.insert(bb, after: other)
     }
 }

--- a/Sources/DLVM/Analysis/Premise.swift
+++ b/Sources/DLVM/Analysis/Premise.swift
@@ -61,7 +61,10 @@ extension BasicBlock : PremiseHolder {
             guard index == body.endIndex - 1 else {
                 throw VerificationError.terminatorNotLast(body)
             }
-            return Premise(first: body[0], terminator: body[index])
+            guard let entry = body.first else {
+                throw VerificationError.noEntry(body)
+            }
+            return Premise(first: entry, terminator: body[index])
         }
     }
 }
@@ -78,18 +81,14 @@ extension Function : PremiseHolder {
 
         public static func run(on body: Function) throws -> Premise {
             var exits: [(BasicBlock, Instruction)] = []
-            var maybeEntry: BasicBlock? = nil
             for bb in body {
-                if bb.isEntry {
-                    maybeEntry = bb
-                }
                 let terminator = try bb.verifyPremise().terminator
                 if case .return = terminator.kind {
                     exits.append((bb, terminator))
                 }
             }
             /// Entry must exist
-            guard let entry = maybeEntry else {
+            guard let entry = body.first else {
                 throw VerificationError.noEntry(body)
             }
             return Premise(entry: entry, exits: exits)

--- a/Sources/DLVM/Analysis/SymbolTable.swift
+++ b/Sources/DLVM/Analysis/SymbolTable.swift
@@ -24,7 +24,8 @@ open class SymbolTableAnalysis : AnalysisPass {
         var table: Result = [:]
         for bb in body {
             for argument in bb.arguments {
-                table[argument.name] = .argument(argument)
+                guard let name = argument.name else { continue }
+                table[name] = .argument(argument)
             }
             for inst in bb {
                 guard let name = inst.name else { continue }

--- a/Sources/DLVM/IR/BasicBlock.swift
+++ b/Sources/DLVM/IR/BasicBlock.swift
@@ -132,7 +132,7 @@ public extension BasicBlock {
     }
 
     var isEntry: Bool {
-        return name == "entry"
+        return indexInParent == 0
     }
 }
 

--- a/Sources/DLVM/IR/BasicBlock.swift
+++ b/Sources/DLVM/IR/BasicBlock.swift
@@ -17,12 +17,12 @@
 //  limitations under the License.
 //
 
-public class Argument : Value, Named, HashableByReference {
-    public var name: String
+public class Argument : NamedValue, HashableByReference {
+    public var name: String?
     public var type: Type
     public unowned var parent: BasicBlock
 
-    public init(name: String, type: Type, parent: BasicBlock) {
+    public init(name: String?, type: Type, parent: BasicBlock) {
         self.name = name
         self.type = type
         self.parent = parent
@@ -33,18 +33,18 @@ public class Argument : Value, Named, HashableByReference {
     }
 }
 
-public final class BasicBlock : IRCollection, IRUnit, Named {
+public final class BasicBlock : IRCollection, IRUnit {
     public typealias Base = OrderedSet<Instruction>
     public typealias Element = Instruction
 
     /// Name of the basic block
-    open var name: String
+    open var name: String?
     open var arguments: OrderedSet<Argument> = []
     open var elements: OrderedSet<Instruction> = []
     open var parent: Function
     public internal(set) var passManager: PassManager<BasicBlock> = PassManager()
 
-    internal init<C: Collection>(name: String, arguments: C, parent: Function)
+    internal init<C: Collection>(name: String?, arguments: C, parent: Function)
         where C.Element == Argument
     {
         self.name = name
@@ -56,8 +56,8 @@ public final class BasicBlock : IRCollection, IRUnit, Named {
         }
     }
 
-    public convenience init<C: Collection>(name: String, arguments: C, parent: Function)
-        where C.Element == (String, Type)
+    public convenience init<C: Collection>(name: String?, arguments: C, parent: Function)
+        where C.Element == (String?, Type)
     {
         self.init(name: name, arguments: [] as [Argument], parent: parent)
         for (name, type) in arguments {
@@ -141,5 +141,23 @@ public extension BasicBlock {
         where C.Element == Type
     {
         return types.elementsEqual(arguments.map{$0.type})
+    }
+}
+
+// MARK: - Naming
+
+public extension Argument {
+    public var printedName: String {
+        if let name = name {
+            return name
+        }
+        let selfIndex = parent.arguments.index(of: self) ?? DLImpossibleResult()
+        return "\(parent.indexInParent)^\(selfIndex)"
+    }
+}
+
+public extension BasicBlock {
+    public var printedName: String {
+        return name ?? indexInParent.description
     }
 }

--- a/Sources/DLVM/IR/Function.swift
+++ b/Sources/DLVM/IR/Function.swift
@@ -45,7 +45,7 @@ public struct AdjointConfiguration : Equatable {
     }
 }
 
-public final class Function : Named, IRCollection, IRUnit {
+public final class Function : IRCollection, IRUnit, NamedValue {
     public enum Attribute {
         /// Inline the function during LLGen
         case inline
@@ -62,7 +62,7 @@ public final class Function : Named, IRCollection, IRUnit {
     public typealias Base = OrderedSet<BasicBlock>
     public typealias Element = BasicBlock
 
-    public var name: String
+    public var name: String?
     public var argumentTypes: [Type]
     public var returnType: Type
     public var attributes: Set<Attribute> = []
@@ -72,7 +72,7 @@ public final class Function : Named, IRCollection, IRUnit {
     public var elements: OrderedSet<BasicBlock> = []
     public internal(set) var passManager: PassManager<Function> = PassManager()
 
-    public init(name: String, argumentTypes: [Type],
+    public init(name: String?, argumentTypes: [Type],
                 returnType: Type, attributes: Set<Attribute> = [],
                 declarationKind: DeclarationKind? = nil, parent: Module) {
         self.name = name
@@ -238,5 +238,13 @@ public extension Function {
             isSeedable ? argumentTypes + [sourceType] : argumentTypes,
             .tuple(diffVars + keptOutputs)
         )
+    }
+}
+
+public extension Function {
+    var printedName: String {
+        if let name = name { return name }
+        let selfIndex = parent.variables.count + indexInParent
+        return selfIndex.description
     }
 }

--- a/Sources/DLVM/IR/IRBuilder.swift
+++ b/Sources/DLVM/IR/IRBuilder.swift
@@ -87,16 +87,16 @@ extension IRBuilder {
     }
 
     @discardableResult
-    open func buildGlobalValue(named name: String,
-                               valueType: Type) -> Variable {
-        let value = Variable(name: name, valueType: valueType)
+    open func buildVariable(named name: String?,
+                            valueType: Type) -> Variable {
+        let value = Variable(name: name, valueType: valueType, parent: module)
         module.variables.append(value)
         return value
     }
 
     @discardableResult
     open func buildFunction(
-        named name: String,
+        named name: String?,
         argumentTypes: [Type],
         returnType: Type = .void,
         attributes: Set<Function.Attribute> = [],
@@ -112,8 +112,8 @@ extension IRBuilder {
     }
 
     @discardableResult
-    open func buildBasicBlock(named name: String,
-                              arguments: DictionaryLiteral<String, Type>,
+    open func buildBasicBlock(named name: String?,
+                              arguments: DictionaryLiteral<String?, Type>,
                               in function: Function) -> BasicBlock {
         let block = BasicBlock(name: name,
                                arguments: arguments.map{($0.0, $0.1)},
@@ -123,7 +123,7 @@ extension IRBuilder {
     }
 
     @discardableResult
-    open func buildEntry(argumentNames: [String],
+    open func buildEntry(argumentNames: [String?],
                          in function: Function) -> BasicBlock {
         let entry = BasicBlock(
             name: "entry",

--- a/Sources/DLVM/IR/Instruction.swift
+++ b/Sources/DLVM/IR/Instruction.swift
@@ -682,6 +682,15 @@ public extension Literal {
     }
 }
 
+// MARK: - Naming
+
+public extension Instruction {
+    public var printedName: String? {
+        return name ??
+            (type.isVoid ? nil : "\(parent.indexInParent).\(indexInParent)")
+    }
+}
+
 // MARK: - Equality
 
 extension InstructionKind : Equatable {

--- a/Sources/DLVM/IR/Instruction.swift
+++ b/Sources/DLVM/IR/Instruction.swift
@@ -698,7 +698,7 @@ public extension Literal {
 // MARK: - Naming
 
 public extension Instruction {
-    public var printedName: String? {
+    var printedName: String? {
         return name ??
             (type.isVoid ? nil : "\(parent.indexInParent).\(indexInParent)")
     }

--- a/Sources/DLVM/IR/Type.swift
+++ b/Sources/DLVM/IR/Type.swift
@@ -26,6 +26,10 @@ public enum Padding : Equatable {
     case full
 }
 
+protocol NominalType : HashableByReference {
+    var name: String { get }
+}
+
 /// Element key to form a key path in GEP and use
 public enum ElementKey : Equatable {
     case index(Int)
@@ -34,7 +38,7 @@ public enum ElementKey : Equatable {
 }
 
 /// Struct type
-public class StructType : Named, HashableByReference {
+public class StructType : NominalType {
     public typealias Field = (name: String, type: Type)
     public var name: String
     public var fields: [Field]
@@ -79,7 +83,7 @@ public extension StructType {
 }
 
 /// Enum type
-public class EnumType : Named, HashableByReference {
+public class EnumType : NominalType {
     public typealias Case = (name: String, associatedTypes: [Type])
     public var name: String
     public var cases: [Case]
@@ -113,7 +117,7 @@ public extension EnumType {
 }
 
 /// Type alias
-public class TypeAlias : Named, HashableByReference {
+public class TypeAlias : NominalType {
     public var name: String
     public var type: Type?
 

--- a/Sources/DLVM/IR/Use.swift
+++ b/Sources/DLVM/IR/Use.swift
@@ -24,21 +24,11 @@ public indirect enum Use : Equatable {
 
 public extension Use {
     var type: Type {
-        get {
-            switch self {
-            case let .literal(t, _):
-                return t
-            case let .definition(x):
-                return x.type
-            }
-        }
-        set(newType) {
-            switch self {
-            case let .literal(_, x):
-                self = .literal(newType, x)
-            case let .definition(x):
-                self = .definition(x)
-            }
+        switch self {
+        case let .literal(t, _):
+            return t
+        case let .definition(x):
+            return x.type
         }
     }
 
@@ -49,7 +39,7 @@ public extension Use {
     var value: Value {
         switch self {
         case let .literal(ty, lit): return LiteralValue(type: ty, literal: lit)
-        case let .definition(def): return def
+        case let .definition(def): return def.value
         }
     }
 

--- a/Sources/DLVM/IR/Use.swift
+++ b/Sources/DLVM/IR/Use.swift
@@ -44,7 +44,8 @@ public extension Use {
     }
 
     var definition: Definition? {
-        return value as? Definition
+        guard case let .definition(def) = self else { return nil }
+        return def
     }
 
     var name: String? {

--- a/Sources/DLVM/IR/Value.swift
+++ b/Sources/DLVM/IR/Value.swift
@@ -38,13 +38,8 @@ public extension Value {
     }
 }
 
-/// Anything that has a name
-public protocol Named {
-    var name: String { get }
-}
-
-/// A named value
-public protocol NamedValue : Value {
+/// Named value
+public protocol NamedValue : Value, AnyObject {
     var name: String? { get }
 }
 
@@ -54,7 +49,7 @@ public protocol User {
 }
 
 /// Definition
-public enum Definition : Hashable, NamedValue {
+public enum Definition : Hashable {
     case argument(Argument)
     case function(Function)
     case instruction(Instruction)
@@ -62,61 +57,28 @@ public enum Definition : Hashable, NamedValue {
 }
 
 public extension Definition {
+    var value: NamedValue {
+        switch self {
+        case let .argument(v): return v
+        case let .instruction(v): return v
+        case let .variable(v): return v
+        case let .function(v): return v
+        }
+    }
+    
     var type: Type {
-        get {
-            switch self {
-            case .argument(let x):
-                return x.type
-            case .instruction(let x):
-                return x.type
-            case .variable(let x):
-                return x.type
-            case .function(let x):
-                return x.type
-            }
-        }
-        set {
-            switch self {
-            case let .argument(x):
-                self = .argument(x)
-            case let .instruction(x):
-                self = .instruction(x)
-            case let .variable(x):
-                self = .variable(x)
-            case let .function(x):
-                self = .function(x)
-            }
-        }
+        return value.type
     }
 
     var name: String? {
-        switch self {
-        case .argument(let x):
-            return x.name
-        case .instruction(let x):
-            return x.name
-        case .variable(let x):
-            return x.name
-        case .function(let x):
-            return x.name
-        }
+        return value.name
     }
 
-    public func makeUse() -> Use {
-        switch self {
-        case .argument(let x): return x.makeUse()
-        case .instruction(let x): return x.makeUse()
-        case .variable(let x): return x.makeUse()
-        case .function(let x): return x.makeUse()
-        }
+    func makeUse() -> Use {
+        return value.makeUse()
     }
-
-    public func performVerification() throws {
-        switch self {
-        case .argument(let x): try x.performVerification()
-        case .instruction(let x): try x.performVerification()
-        case .variable(let x): try x.performVerification()
-        case .function(let x): try x.performVerification()
-        }
+    
+    static prefix func % (definition: Definition) -> Use {
+        return definition.makeUse()
     }
 }

--- a/Sources/DLVM/IR/Variable.swift
+++ b/Sources/DLVM/IR/Variable.swift
@@ -1,5 +1,5 @@
 //
-//  GlobalVariable.swift
+//  Variable.swift
 //  DLVM
 //
 //  Copyright 2016-2018 The DLVM Team.
@@ -18,14 +18,17 @@
 //
 
 /// Global variable
-public class Variable: Named, HashableByReference {
-    public var name: String
+public class Variable : NamedValue, HashableByReference {
+    public var name: String?
     /// The type of the underlying value of the variable
     public var valueType: Type
+    
+    unowned var parent: Module
 
-    public init(name: String, valueType: Type) {
+    public init(name: String?, valueType: Type, parent: Module) {
         self.name = name
         self.valueType = valueType
+        self.parent = parent
     }
 
     /// The pointer type wrapping the value type of the variable
@@ -37,5 +40,13 @@ public class Variable: Named, HashableByReference {
 extension Variable : Value {
     public func makeUse() -> Use {
         return .definition(.variable(self))
+    }
+}
+
+public extension Variable {
+    var printedName: String {
+        if let name = name { return name }
+        let selfIndex = parent.variables.index(of: self) ?? DLImpossibleResult()
+        return selfIndex.description
     }
 }

--- a/Sources/DLVM/IR/Verification.swift
+++ b/Sources/DLVM/IR/Verification.swift
@@ -126,7 +126,7 @@ extension Module : Verifiable {
     private func verify<T: Verifiable & NamedValue>
         (_ declaration: T, namespace: inout Set<String>) throws {
         if let name = declaration.name {
-            guard namespace.contains(name) else {
+            guard !namespace.contains(name) else {
                 throw VerificationError.redeclared(declaration)
             }
             namespace.insert(name)
@@ -136,7 +136,7 @@ extension Module : Verifiable {
     
     private func verify<T: Verifiable & NominalType>
         (_ declaration: T, namespace: inout Set<String>) throws {
-        guard namespace.contains(declaration.name) else {
+        guard !namespace.contains(declaration.name) else {
             throw VerificationError.redeclared(declaration)
         }
         namespace.insert(declaration.name)

--- a/Sources/DLVM/IR/Writer.swift
+++ b/Sources/DLVM/IR/Writer.swift
@@ -162,9 +162,9 @@ extension InstructionKind : TextOutputStreamable {
     public func write<Target : TextOutputStream>(to target: inout Target) {
         switch self {
         case let .branch(bb, args):
-            target.write("branch '\(bb.name)(\(args.joinedDescription))")
+            target.write("branch '\(bb.printedName)(\(args.joinedDescription))")
         case let .conditional(op, thenBB, thenArgs, elseBB, elseArgs):
-            target.write("conditional \(op) then '\(thenBB.name)(\(thenArgs.joinedDescription)) else '\(elseBB.name)(\(elseArgs.joinedDescription))")
+            target.write("conditional \(op) then '\(thenBB.printedName)(\(thenArgs.joinedDescription)) else '\(elseBB.printedName)(\(elseArgs.joinedDescription))")
         case let .return(op):
             target.write("return")
             if let op = op {
@@ -249,7 +249,7 @@ extension InstructionKind : TextOutputStreamable {
         case let .branchEnum(e1, branches):
             target.write("branchEnum \(e1)")
             for (name, bb) in branches {
-                target.write(" case ?\(name) '\(bb.name)")
+                target.write(" case ?\(name) '\(bb.printedName)")
             }
         case let .allocateStack(t, n):
             target.write("allocateStack \(t) count \(n)")
@@ -286,10 +286,6 @@ extension InstructionKind : TextOutputStreamable {
 }
 
 extension Instruction : TextOutputStreamable {
-    public var printedName: String? {
-        return name ?? (type.isVoid ? nil : "\(parent.indexInParent).\(indexInParent)")
-    }
-
     public func write<Target : TextOutputStream>(to target: inout Target) {
         if let name = printedName {
             target.write("%\(name) = ")
@@ -300,7 +296,7 @@ extension Instruction : TextOutputStreamable {
 
 extension Variable : TextOutputStreamable {
     public func write<Target : TextOutputStream>(to target: inout Target) {
-        target.write("var @\(name): \(valueType)")
+        target.write("var @\(printedName): \(valueType)")
     }
 }
 
@@ -335,13 +331,13 @@ extension Use : TextOutputStreamable {
         case let .literal(_, lit):
             return lit.description
         case let .definition(.variable(ref)):
-            return "@\(ref.name)"
+            return "@\(ref.printedName)"
         case let .definition(.instruction(ref)):
             return ref.printedName.flatMap{"%\($0)"} ?? "%_"
         case let .definition(.argument(ref)):
-            return "%\(ref.name)"
+            return "%\(ref.printedName)"
         case let .definition(.function(ref)):
-            return "@\(ref.name)"
+            return "@\(ref.printedName)"
         }
     }
 }
@@ -353,7 +349,7 @@ extension BasicBlock : TextOutputStreamable {
 
     public func write<Target : TextOutputStream>(to target: inout Target) {
         /// Begin block
-        target.write("'\(name)(\(arguments.map{"\($0)"}.joined(separator: ", "))):\n")
+        target.write("'\(printedName)(\(arguments.map{"\($0)"}.joined(separator: ", "))):\n")
         for inst in elements {
             /// Write indentation
             makeIndentation().write(to: &target)
@@ -365,7 +361,7 @@ extension BasicBlock : TextOutputStreamable {
 
 extension Argument : TextOutputStreamable {
     public func write<Target>(to target: inout Target) where Target : TextOutputStream {
-        target.write("%\(name): \(type)")
+        target.write("%\(printedName): \(type)")
     }
 }
 
@@ -388,7 +384,7 @@ extension Function : TextOutputStreamable {
         case .external?:
             target.write("[extern]\n")
         case let .adjoint(config)?:
-            target.write("[adjoint @\(config.primal.name)")
+            target.write("[adjoint @\(config.primal.printedName)")
             config.sourceIndex.ifAny {
                 target.write(" from \($0)")
             }
@@ -406,7 +402,7 @@ extension Function : TextOutputStreamable {
             break
         }
         target.write("func ")
-        target.write("@\(name): \(type)")
+        target.write("@\(printedName): \(type)")
         if isDefinition {
             target.write(" {\n")
             for bb in self {

--- a/Sources/DLVM/Transform/Differentiation.swift
+++ b/Sources/DLVM/Transform/Differentiation.swift
@@ -148,9 +148,7 @@ fileprivate extension Differentiation {
                 /// Create preheader and connect it with header
                 let preheader = BasicBlock(
                     name: adjoint.makeFreshName("preheader"),
-                    arguments: loop.header.arguments.map{
-                        (adjoint.makeFreshName($0.name), $0.type)
-                    },
+                    arguments: loop.header.arguments.map { (nil, $0.type) },
                     parent: adjoint)
                 adjoint.insert(preheader, before: loop.header)
                 builder.move(to: preheader)
@@ -231,7 +229,7 @@ fileprivate extension Differentiation {
                 guard let argAdjoint = context.adjoint(for: %adjoint[0].arguments[i]) else {
                     fatalError("""
                         Adjoint not found for argument \(adjoint[0].arguments[i]) \
-                        in function \(adjoint.name)
+                        in function \(adjoint.printedName)
                         """)
                 }
                 return argAdjoint
@@ -276,10 +274,10 @@ fileprivate extension Differentiation {
                                                        keeping: [],
                                                        seedable: true),
                     case let .function(argumentTypes, returnType) = adjointType else {
-                        fatalError("Function @\(fn.name) is not differentiable")
+                    DLImpossible("Function @\(fn.printedName) is not differentiable")
                 }
                 let module = fn.parent
-                let adjointName = module.makeFreshFunctionName("\(fn.name)_grad")
+                let adjointName = fn.name.map { module.makeFreshFunctionName("\($0)_grad") }
                 adjoint = Function(name: adjointName,
                                    argumentTypes: argumentTypes,
                                    returnType: returnType,

--- a/Sources/DLVM/Transform/Differentiation.swift
+++ b/Sources/DLVM/Transform/Differentiation.swift
@@ -229,7 +229,7 @@ fileprivate extension Differentiation {
                 guard let argAdjoint = context.adjoint(for: %adjoint[0].arguments[i]) else {
                     fatalError("""
                         Adjoint not found for argument \(adjoint[0].arguments[i]) \
-                        in function \(adjoint.printedName)
+                        in function \(adjoint.printedName).
                         """)
                 }
                 return argAdjoint

--- a/Sources/DLVM/Transform/LiteralBroadcastingPromotion.swift
+++ b/Sources/DLVM/Transform/LiteralBroadcastingPromotion.swift
@@ -42,7 +42,7 @@ open class LiteralBroadcastingPromotion : TransformPass {
                 case .definition(.instruction(let i)):
                     guard case let .literal(lit, ty) = i.kind,
                         case let .tensor(_, dt) = ty else {
-                            break
+                        break
                     }
                     changed = true
                     inst.substitute(.literal(.scalar(dt), lit), for: operand)

--- a/Sources/DLVM/Transform/LiteralBroadcastingPromotion.swift
+++ b/Sources/DLVM/Transform/LiteralBroadcastingPromotion.swift
@@ -28,17 +28,17 @@ open class LiteralBroadcastingPromotion : TransformPass {
             case .numericBinary, .booleanBinary, .compare: break
             default: continue
             }
-            for var operand in inst.operands {
+            for operand in inst.operands {
                 /// Operand must have tensor type
                 guard case let .tensor(_, dt) = operand.type else {
                     continue
                 }
                 /// Operand must be a literal or literal instruction
                 switch operand {
-                case .literal(_, .scalar(_)):
+                case let .literal(_, .scalar(sLit)):
+                    let newOperand: Use = .literal(.scalar(dt), .scalar(sLit))
+                    inst.substitute(newOperand, for: operand)
                     changed = true
-                    operand.type = .scalar(dt)
-                    inst.substitute(operand, for: operand)
                 case .definition(.instruction(let i)):
                     guard case let .literal(lit, ty) = i.kind,
                         case let .tensor(_, dt) = ty else {

--- a/Tests/DLVMTests/IRTests.swift
+++ b/Tests/DLVMTests/IRTests.swift
@@ -31,7 +31,7 @@ class IRTests : XCTestCase {
         ])
 
     lazy var struct1Global =
-        builder.buildGlobalValue(named: "struct1", valueType: struct1.type)
+        builder.buildVariable(named: "struct1", valueType: struct1.type)
 
     var enum1: EnumType {
         let tmp = builder.buildEnum(
@@ -42,7 +42,7 @@ class IRTests : XCTestCase {
     }
 
     lazy var enum1Global: Variable =
-        builder.buildGlobalValue(named: "enum1", valueType: enum1.type)
+        builder.buildVariable(named: "enum1", valueType: enum1.type)
 
     func testInitializeStruct() {
         let structLit: Literal = .struct([
@@ -101,9 +101,9 @@ class IRTests : XCTestCase {
     }
 
     func testWriteGlobal() {
-        let val1 = builder.buildGlobalValue(named: "one", valueType: .int(32))
+        let val1 = builder.buildVariable(named: "one", valueType: .int(32))
         XCTAssertEqual("\(val1)", "var @one: i32")
-        let val2 = builder.buildGlobalValue(named: "two", valueType: *.int(32))
+        let val2 = builder.buildVariable(named: "two", valueType: *.int(32))
         XCTAssertEqual("\(val2)", "var @two: *i32")
     }
 

--- a/Tests/DLVMTests/TransformTests.swift
+++ b/Tests/DLVMTests/TransformTests.swift
@@ -276,8 +276,8 @@ class TransformTests : XCTestCase {
                 branch 'then_join(0: i32)
             'nested_else():
                 branch 'then_join(1: i32)
-            'then_join(%exit_value_0: i32):
-                branch 'exit(%exit_value_0: i32)
+            'then_join(%5^0: i32):
+                branch 'exit(%5^0: i32)
             'exit(%exit_value: i32):
                 return %exit_value: i32
             }


### PR DESCRIPTION
Make definitions, i.e. `Argument`, `BasicBlock`, `Function` and `Variable`, optionally anonymous.

TODO: 
- Update tests
- Clean up hacky fresh name helpers.
- Parse anonymous identifiers.