### PR TITLE
Fix project URL.

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -33,4 +33,4 @@ E: zheng321@purdue.edu
 W: http://danzheng.me
 D: Contributor to almost everything, including the infrastructure, IR,
    transforms, command line tools and DSLs. Maintaining project website
-   dlvm.org.
+   dlvm-team.github.io.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Core Compiler Infrastructure
 
 Welcome to DLVM! For general information about the DLVM project,
-please visit [dlvm.org](http://dlvm.org).
+please visit [dlvm-team.github.io](https://dlvm-team.github.io).
 
 This repository does not include a code generator.
 


### PR DESCRIPTION
[dlvm-team.github.io](https://dlvm-team.github.io/) is the stable project URL.
We have not had ownership of [dlvm.org](http://dlvm.org/) for quite some time now.

---

Resolves #93.